### PR TITLE
Ensure Correct Callback Execution Order for selectedText in Drawing Function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvas-text-grabber",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "an interactive sketch tool that allows users to draw a selection area on a web page and capture text within that area.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,13 +220,14 @@ export class CanvasTextGrabber {
         const elements = this.getSelectedElements();
         const text = this.getTextFromDomElements(elements);
 
+        if (this.onTextSelectedCallback) {
+            this.onTextSelectedCallback(text);
+        }
+
         if (this.onDrawingFinishedCallback) {
             this.onDrawingFinishedCallback(true);
         }
 
-        if (this.onTextSelectedCallback) {
-            this.onTextSelectedCallback(text);
-        }
     }
 
     private addEventListeners(element: HTMLElement, eventHandlerOptionsTriples: Array<[string, EventListener | EventListenerObject, boolean | AddEventListenerOptions | undefined]>) {


### PR DESCRIPTION
**Issue:**
The current implementation has an issue where `sketch.isDrawingFinished()` is being called before the `selectedText` callback is executed. This premature call leads to unexpected behaviors as the drawing operation is marked as complete before the `selectedText` processing occurs.

**Solution:**
This PR addresses the issue by adjusting the execution order of the callbacks.
