### PR TITLE
Refine onDrawingFinishedCallback to Directly Return Selected DOM Elements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,5 @@
-import type * as CSS from 'csstype';
 import { mergeStyles } from './helpers.js'
-type Options = {
-    selectedElementsClass: string,
-    selectedElementsStyle: Partial<CSS.Properties>,
-    stokeStyle: string,
-    lineWidth: number,
-    lineCap: CanvasLineCap,
-    canvasStyles: Partial<CSS.Properties>,
-    canvasId: string,
-    spanClass: string,
-    spanWrapperClass: string,
-    spanStyle: Partial<CSS.Properties>,
-    spanWrapperStyle: Partial<CSS.Properties>
-}
-
-type DrawingFinishedCallback = (finished: boolean) => void;
-type TextSelectedCallback = (text: string | undefined) => void;
+import type { DrawingFinishedCallback, Options, TextSelectedCallback } from './type.js';
 
 
 const defaultOptions: Options = {
@@ -253,7 +237,7 @@ export class CanvasTextGrabber {
         }
 
         if (this.onDrawingFinishedCallback) {
-            this.onDrawingFinishedCallback(true);
+            this.onDrawingFinishedCallback(elements);
         }
 
     }

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,0 +1,18 @@
+import type * as CSS from 'csstype';
+
+export type Options = {
+    selectedElementsClass: string,
+    selectedElementsStyle: Partial<CSS.Properties>,
+    stokeStyle: string,
+    lineWidth: number,
+    lineCap: CanvasLineCap,
+    canvasStyles: Partial<CSS.Properties>,
+    canvasId: string,
+    spanClass: string,
+    spanWrapperClass: string,
+    spanStyle: Partial<CSS.Properties>,
+    spanWrapperStyle: Partial<CSS.Properties>
+}
+
+export type DrawingFinishedCallback = (selectedDOMElements: Element[] | undefined) => void;
+export type TextSelectedCallback = (text: string | undefined) => void;


### PR DESCRIPTION
### Description

This PR enhances the `onDrawingFinishedCallback` within the `CanvasTextGrabber` by streamlining its functionality. We've removed the redundant `finished` boolean parameter, as the callback's invocation inherently indicates that the drawing action has concluded. Now, `onDrawingFinishedCallback` solely returns an array of selected DOM elements, enabling more straightforward and powerful interactions for developers, such as custom animations or element manipulations post-selection.

### Changes

- Updated `onDrawingFinishedCallback` to return an array of DOM elements directly.

### Implementation Details

The callback function signature has been simplified to:

```typescript
type DrawingFinishedCallback = (selectedElements: Element[]) => void;
```

This change focuses on delivering immediate value by providing access to the selected elements, thereby enhancing the capability for developers to implement rich, post-selection features seamlessly.

### Adjustments for Users

Users leveraging the `onDrawingFinishedCallback` will need to update their implementation to accommodate the removal of the `finished` boolean. Here's how to transition:

**Previous Implementation:**

```javascript
grabber.onDrawingFinished((finished) => {
  if (finished) {
    // Logic for when drawing is finished
  }
});
```

**New Implementation:**

```javascript
grabber.onDrawingFinished((selectedElements) => {
  console.log('Selected elements:', selectedElements);
  // Apply custom logic to selected elements, e.g., animations
  selectedElements.forEach(el => el.classList.add('custom-animation'));
});
```

### Benefits

- **Enhanced Flexibility**: Direct access to selected elements paves the way for more creative and complex post-selection interactions.